### PR TITLE
Transpose DCT coefficients within each block

### DIFF
--- a/jpeglib/cjpeglib/cjpeglib_dct.cpp
+++ b/jpeglib/cjpeglib/cjpeglib_dct.cpp
@@ -71,7 +71,7 @@ int read_jpeg_dct(
 				blockptr_one = buffer_one[0][w];
 				for(int bh = 0; bh < 8; bh++) {
 				for(int bw = 0; bw < 8; bw++) {
-					int i = bw*8 + bh;
+					int i = bh*8 + bw;
 					((short *)_dct_offset(dct, ch, h, w, Hblocks, Wblocks))[i] = blockptr_one[bh*8 + bw];
 				}
 				// memcpy(_dct_offset(dct, ch, w, h, WblocksY, HblocksY), (void *)blockptr_one, sizeof(short)*64);
@@ -350,7 +350,7 @@ int write_jpeg_dct(
 					blockptr_one = buffer_one[0][w];
 					for (int bh = 0; bh < 8; bh++)
 						for (int bw = 0; bw < 8; bw++)
-							blockptr_one[bh * 8 + bw] = ((short *)_dct_offset(dct, ch, h, w, Hblocks, Wblocks))[bw * 8 + bh];
+							blockptr_one[bh * 8 + bw] = ((short *)_dct_offset(dct, ch, h, w, Hblocks, Wblocks))[bh * 8 + bw];
 				}
 			}
 		}

--- a/tests/test_dct.py
+++ b/tests/test_dct.py
@@ -166,7 +166,7 @@ class TestDCT(unittest.TestCase):
             np.testing.assert_array_equal(qt_ref, qt)
 
     def test_dct_coefficient_decoder(self):
-        """Test output against blorch/dct-coefficient-decoder."""
+        """Test output against btlorch/dct-coefficient-decoder."""
         self.logger.info("test_dct_coefficient_decoder")
         # read DCT with jpeglib
         im = jpeglib.read_dct("examples/IMG_0311.jpeg")
@@ -187,16 +187,14 @@ class TestDCT(unittest.TestCase):
         ])
         YT = (
             d.get_dct_coefficients(0)
-            .reshape((im.width_in_blocks(0), -1, 8, 8), order='F')
-            .transpose((1, 0, 2, 3)))
+            .reshape((im.height_in_blocks(0), im.width_in_blocks(0), 8, 8)))
         CbT = (
             d.get_dct_coefficients(1)
-            .reshape((im.width_in_blocks(1), -1, 8, 8), order='F')
-            .transpose((1, 0, 2, 3)))
+            .reshape((im.height_in_blocks(1), im.width_in_blocks(1), 8, 8)))
         CrT = (
             d.get_dct_coefficients(2)
-            .reshape((im.width_in_blocks(2), -1, 8, 8), order='F')
-            .transpose((1, 0, 2, 3)))
+            .reshape((im.height_in_blocks(2), im.width_in_blocks(2), 8, 8)))
+
         # test equal
         np.testing.assert_array_equal(im.Y, YT)
         np.testing.assert_array_equal(im.Cb, CbT)


### PR DESCRIPTION
Reorganize DCT coefficients such that horizontal frequencies are arranged left-to-right and vertical frequencies are arranged top-to-bottom, analogous to Matlab's JPEG toolbox, jpegio and the DCT coefficient decoder