### PR TITLE
Fix issue with chroma sub-sampling format inference.

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -58,17 +58,16 @@ hmax and wmax (2 and 3) and normalizing factors with the respective maximum; now
 Thus multiplied by the image size, Y has 300 x 300, Cb 150 x 200 and Cr 300 x 100.
 
 You can specify the chroma subsampling before writing a JPEG image as follows:
-```python
-# im is a jpeglib.JPEG object
 
-# Variant 1: Specify in J:a:b notation
-im.samp_factor = '4:4:4'
-
-# Variant 2: Specify per-channel sampling factors as a list [[vY, hY], [vCb, hCb],[vCr, hCr]]
-im.samp_factor = [[1, 1], [1, 1], [1, 1]]
-
-# now you can write im to a file
-```
+>>> # im is a jpeglib.JPEG object
+>>>
+>>> # Variant 1: Specify in J:a:b notation
+>>> im.samp_factor = '4:4:4'
+>>>
+>>> # Variant 2: Specify per-channel sampling factors as a list [[vY, hY], [vCb, hCb],[vCr, hCr]]
+>>> im.samp_factor = [[1, 1], [1, 1], [1, 1]]
+>>>
+>>> # now you can write im to a file
 
 Flags
 """""

--- a/jpeglib/_infere.py
+++ b/jpeglib/_infere.py
@@ -143,10 +143,10 @@ def samp_factor(
         # compute sampling factor
         dims = np.array([np.array(Y.shape[:2]) / np.array(i) for i in dims])
         max_subs = np.max(dims, axis=0)
-        factor = np.array([
+        factor = np.ceil(np.array([
             max_subs,
             *(max_subs / dims)
-        ]).astype('int16')
+        ])).astype('int16')
     return factor
 
 


### PR DESCRIPTION
Fix an issue with some picture dimensions using jpeglib.from_dct such as 800x600 with 4:2:0 chroma subsamping format causing "Bogus virtual array access" error on save. Infere sampling factor using ceiling rather than truncating on int16 conversion.

[https://github.com/martinbenes1996/jpeglib/issues/9](url)