### PR TITLE
Replace pkg_resources by importlib.metadata

### DIFF
--- a/src/jpeglib/__init__.py
+++ b/src/jpeglib/__init__.py
@@ -41,10 +41,10 @@ JPEG_APP1 = MarkerType.JPEG_APP1
 JPEG_COM = MarkerType.JPEG_COM
 
 # package version
-import pkg_resources
+import importlib.metadata
 try:
-    __version__ = pkg_resources.get_distribution("jpeglib").version
-except pkg_resources.DistributionNotFound:
+    __version__ = importlib.metadata.version("jpeglib")
+except importlib.metadata.PackageNotFoundError:
     __version__ = None
 
 # set default version


### PR DESCRIPTION
This PR replaces the use of `pkg_resources` in `__init__.py` by `importlib.metadata`, as the former is now deprecated.

Currently, when importing `jpeglib` with python 3.12, we get the following warning:
```
>>> import jpeglib
/.venv/lib/python3.12/site-packages/jpeglib/__init__.py:44: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
```

This PR fixes it.